### PR TITLE
Make entries container wider so more space for content

### DIFF
--- a/app/assets/stylesheets/_entries.css.scss
+++ b/app/assets/stylesheets/_entries.css.scss
@@ -32,6 +32,10 @@
       font-size: 0.9em;
     }
   }
+
+  .container {
+    width: 90%;
+  }
 }
 
 .new_entry_wrapper {


### PR DESCRIPTION
Now (on my small macbook air screen):
![screen shot 2014-04-03 at 18 02 15](https://cloud.githubusercontent.com/assets/642544/2605884/5f3c4170-bb49-11e3-98d8-69505915981d.png)

WIth this PR:
![screen shot 2014-04-03 at 18 03 14](https://cloud.githubusercontent.com/assets/642544/2605896/7d70b57c-bb49-11e3-81d6-2ea1ad3f2311.png)
