### PR TITLE
Sign out with a get request

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -34,7 +34,7 @@
               </li>
               <li class="devider"></li>
               <li>
-                <a data-method="delete" href="/users/sign_out"><%= t("sign_out") %></a>
+                <%= link_to t("sign_out"), destroy_user_session_path %>
               </li>
             </ul>
           </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -230,7 +230,7 @@ Devise.setup do |config|
   # config.navigational_formats = ["*/*", :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
This PR fixes the problem of `No route matches [GET] "/users/sign_out"` by changing the devise setting
`config.sign_out_via` to `:get`.
