### PR TITLE
[READY] Upgrade chart.js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+source "https://rails-assets.org"
 
 ruby "2.1.2"
 
@@ -33,6 +34,7 @@ gem "kaminari"
 gem "select2-rails"
 gem "http_accept_language"
 gem "normalize-rails"
+gem "rails-assets-chartjs", "~> 1.0.1.beta.4"
 
 # caching
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actionmailer (4.1.5)
       actionpack (= 4.1.5)
@@ -189,6 +190,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.5)
       sprockets-rails (~> 2.0)
+    rails-assets-chartjs (1.0.1.beta.4)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
@@ -334,6 +336,7 @@ DEPENDENCIES
   pry-rails
   rack-timeout
   rails (~> 4.1.5)
+  rails-assets-chartjs (~> 1.0.1.beta.4)
   rails_12factor
   recipient_interceptor
   rspec-rails (>= 2.14)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,7 @@
 //= require moment
 //= require pikaday
 //= require selectize
-//= require Chart
+//= require chartjs
 //= require select2
 //= require projects
 //= require i18n


### PR DESCRIPTION
This PR is mainly to see if we can switch to chartJS's 1.0.1 beta (source: https://github.com/nnnick/Chart.js/releases/tag/v1.0.1-beta.3)

I have manually included the library: 7793067f191c835d4a6811e36becb956b2c11c62

Everything seems to work fine, maybe someone can confirm?
