### PR TITLE
add brakeman security scan to default rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   gem "pry-rails"
   gem "rspec-rails", ">= 2.14"
   gem "annotate"
+  gem "brakeman"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,17 @@ GEM
     bourbon (3.2.3)
       sass (~> 3.2)
       thor
+    brakeman (2.6.1)
+      erubis (~> 2.6)
+      fastercsv (~> 1.5)
+      haml (>= 3.0, < 5.0)
+      highline (~> 1.6.20)
+      multi_json (~> 1.2)
+      ruby2ruby (~> 2.0.5)
+      ruby_parser (~> 3.5.0)
+      sass (~> 3.0)
+      slim (>= 1.3.6, < 3.0)
+      terminal-table (~> 1.4)
     builder (3.2.2)
     capybara (2.3.0)
       mime-types (>= 1.16)
@@ -105,13 +116,17 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
+    fastercsv (1.5.5)
     flutie (2.0.0)
     foreman (0.74.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
     gravatar_image_tag (1.2.0)
+    haml (4.0.5)
+      tilt
     hashtel (0.0.2)
     high_voltage (2.2.0)
+    highline (1.6.21)
     hike (1.2.3)
     http_accept_language (2.0.1)
     i18n (0.6.11)
@@ -193,6 +208,11 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.2)
+    ruby2ruby (2.0.7)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.5.0)
+      sexp_processor (~> 4.1)
     safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.2)
@@ -202,6 +222,7 @@ GEM
       sprockets-rails (~> 2.0.0)
     select2-rails (3.5.9)
       thor (~> 0.14)
+    sexp_processor (4.4.3)
     shoulda-matchers (2.6.1)
       activesupport (>= 3.0.0)
     simple_form (3.0.2)
@@ -212,6 +233,9 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slim (2.0.2)
+      temple (~> 0.6.6)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.5.0)
     spring (1.1.3)
     spring-commands-rspec (1.0.2)
@@ -225,6 +249,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    temple (0.6.7)
+    terminal-table (1.4.5)
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -264,6 +290,7 @@ DEPENDENCIES
   binding_of_caller
   bitters
   bourbon
+  brakeman
   capybara-webkit (>= 1.0.0)
   chart-js-rails
   coffee-rails

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,23 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path("../config/application", __FILE__)
 
 Hours::Application.load_tasks
 if defined?(RSpec)
   task(:spec).clear
 
-  desc 'Run all specs'
+  desc "Run all specs"
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = '--tag ~factory'
+    t.rspec_opts = "--tag ~factory"
   end
 
-  desc 'Run factory specs.'
+  desc "Run factory specs."
   RSpec::Core::RakeTask.new(:factory_specs) do |t|
-    t.pattern = './spec/models/factories_spec.rb'
+    t.pattern = "./spec/models/factories_spec.rb"
   end
 
   task spec: :factory_specs
 end
 task(:default).clear
-task :default => [:spec]
+task :default => [:spec, "brakeman:run"]

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,0 +1,9 @@
+namespace :brakeman do
+
+  desc "Run Brakeman"
+  task :run do |t|
+    require "brakeman"
+
+    Brakeman.run :app_path => ".", :print_report => true
+  end
+end


### PR DESCRIPTION
This will add a report on some common rails security pitfalls to the output of CI and locally ran specs like:

```
+BRAKEMAN REPORT+

Application path: /Users/jurre/defacto/Hours
Rails version: 4.1.4
Brakeman version: 2.6.1
Started at 2014-08-06 17:53:04 +0200
Duration: 0.52935 seconds
Checks run: BasicAuth, ContentTag, CrossSiteScripting, DefaultRoutes, Deserialize, DetailedExceptions, DigestDoS, EscapeFunction, Evaluation, Execute, FileAccess, FilterSkipping, ForgerySetting, HeaderDoS, I18nXSS, JRubyXML, JSONParsing, LinkTo, LinkToHref, MailTo, MassAssignment, ModelAttrAccessible, ModelAttributes, ModelSerialize, NestedAttributes, NumberToCurrency, QuoteTableName, Redirect, RegexDoS, Render, RenderDoS, ResponseSplitting, SQL, SQLCVEs, SSLVerify, SafeBufferManipulation, SanitizeMethods, SelectTag, SelectVulnerability, Send, SendFile, SessionSettings, SimpleFormat, SingleQuotes, SkipBeforeFilter, StripTags, SymbolDoS, TranslateBug, UnsafeReflection, ValidationRegex, WithoutProtection, YAMLParsing


+SUMMARY+

+-------------------+-------+
| Scanned/Reported  | Total |
+-------------------+-------+
| Controllers       | 9     |
| Models            | 8     |
| Templates         | 32    |
| Errors            | 0     |
| Security Warnings | 0 (0) |
+-------------------+-------+
```
