### PR TITLE
allow owners to delete their tenant/account

### DIFF
--- a/app/assets/stylesheets/_account.css.scss
+++ b/app/assets/stylesheets/_account.css.scss
@@ -1,0 +1,15 @@
+.danger-zone {
+  background-color: $danger-color;
+  padding: 20px;
+  border-radius: 4px;
+  border: darken($danger-color, 20%);
+
+  margin-top: 20px;
+
+  input {
+    background-color: darken($danger-color, 20%);
+    &:hover {
+      background-color: darken($danger-color, 30%);
+    }
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -12,6 +12,7 @@
 @import "projects";
 @import "entries";
 @import "users";
+@import "account";
 @import "modal";
 @import url(//fonts.googleapis.com/css?family=Open+Sans);
 @import "pikaday";

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -43,6 +43,8 @@ $error-color: $light-red;
 $notice-color: $light-yellow;
 $success-color: $light-green;
 
+$danger-color: $error-color;
+
 // Forms
 $form-border-color: $base-border-color;
 $form-border-color-hover: darken($base-border-color, 10);

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,6 @@
 class AccountsController < ApplicationController
-  skip_before_filter :authenticate_user!, only: [:new, :create]
+  skip_before_action :authenticate_user!, only: [:new, :create]
+  before_action :authorize!, only: [:edit, :destroy]
 
   def new
     @account = Account.new
@@ -18,6 +19,15 @@ class AccountsController < ApplicationController
     end
   end
 
+  def edit
+    @current_domain = request.host
+  end
+
+  def destroy
+    current_account.destroy
+    Apartment::Tenant.drop(current_subdomain)
+  end
+
   private
 
   def account_params
@@ -27,5 +37,9 @@ class AccountsController < ApplicationController
                     :first_name, :last_name, :email,
                     :password, :password_confirmation]
                  )
+  end
+
+  def authorize!
+    raise ActiveRecord::RecordNotFound unless current_user_owner?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,10 @@ class ApplicationController < ActionController::Base
     @current_subdomain ||= current_account.subdomain
   end
 
+  helper_method def current_user_owner?
+    current_account.owner == current_user
+  end
+
   def load_schema
     Apartment::Tenant.switch("public")
     return unless request.subdomain.present?

--- a/app/views/accounts/destroy.html.erb
+++ b/app/views/accounts/destroy.html.erb
@@ -1,0 +1,3 @@
+<div id="flash">
+  <div id="flash-notice"><%= t("account.deleted") %></div>
+</div>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -1,0 +1,18 @@
+<div class="outer" >
+  <div class="container" >
+    <h1><%= title %></h1>
+
+    <div class="danger-zone">
+      <h2><%= t("account.danger_zone") %></h2>
+      <p><%= t("account.warning", subdomain: @current_domain) %></p>
+
+      <%= button_to(
+        t("account.delete"),
+        { controller: :accounts, action: :destroy },
+        method: :delete,
+        data: { confirm: t("account.confirm_destroy") }
+      ) %>
+
+    </div>
+  </div>
+</div>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -25,6 +25,11 @@
                 <li>
                   <%= link_to t("navbar.dropdown.edit_user"), edit_user_registration_path %>
                 </li>
+                <% if current_user_owner? %>
+                  <li>
+                  <%= link_to t("titles.accounts.edit"), edit_account_path %>
+                  </li>
+                <% end %>
                 <% if Hours.helpful_enabled? %>
                   <li >
                     <div class="modal">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     application: Hours
     accounts:
       new: Registration
+      edit: Edit Account
     projects:
       index: Projects
       new: New Project
@@ -115,6 +116,11 @@ en:
     repeat_password: Repeat Password
     subdomain: Subdomain
     back_to_website: back to the website
+    danger_zone: Danger Zone
+    warning: Deleting your account will remove you and everyone else's data from %{subdomain} and cannot be undone.
+    delete: Delete my account
+    confirm_destroy: Are you sure you want to delete your account?
+    deleted: Your account was deleted. Sorry to see you go. :(
 
   project:
     table_head:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,6 +2,10 @@
 nl:
   account:
     back_to_website: Terug naar website
+    confirm_destroy: Weet je zeker dat je je account wil verwijderen?
+    danger_zone: Danger Zone
+    delete: Verwijder mijn account
+    deleted: Je account is verwijderd.
     email: Email
     first_name: Voornaam
     invalid_characters: bevat invalide karakters
@@ -10,6 +14,7 @@ nl:
     repeat_password: Bevesting wachtwoord
     restricted: restricted
     subdomain: subdomein
+    warning: Het verwijderen van je account zal jouw en iedereens gegevens op %{subdomain} verwijderen en kan niet ongedaan worden gemaakt.
   account_created_successfully: Aanmelden is gelukt
   activerecord:
     errors:
@@ -115,6 +120,10 @@ nl:
     tagline: Heeft u een vraag over Hours? Hulp nodig om te kunnen beginnen?
     title: Hulp nodig?
   hours: uren
+  info:
+    here: hier
+    no_categories_html: Zo te zien heb je nog geen categorieen aangemaakt. Dat kun je %{categorie_path} doen. 
+    no_projects_html: Zo te zien heb je nog geen projecten aangemaakt. Dat kun je %{new_project_path} doen.
   main_text: Hier moet een supertoffe text komen te staan in het nederlands over hoe
     tof hours is
   navbar:
@@ -162,6 +171,7 @@ nl:
       short: "%B %d"
   titles:
     accounts:
+      edit: Account Aanpassen
       new: Registratie
     activities: Activiteiten
     application: Uren

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Hours::Application.routes.draw do
     resources :users, only: [] do
       resources :entries, only: :index
     end
+
+    get "account/edit" => "accounts#edit", as: :edit_account
+    delete "account" => "accounts#destroy", as: :destroy_account
   end
 
   constraints(SubdomainBlank) do

--- a/spec/features/owner_deletes_account_spec.rb
+++ b/spec/features/owner_deletes_account_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+feature "Delete Account" do
+  let(:subdomain) { generate(:subdomain) }
+  let(:owner) { build(:user) }
+
+  before(:each) do
+    create(:account_with_schema, subdomain: subdomain, owner: owner)
+  end
+
+  context "as the owner of an account" do
+    scenario "deleting the account" do
+      sign_in_user(owner, subdomain: subdomain)
+
+      visit edit_account_url(subdomain: subdomain)
+      expect(page).to have_content "Danger Zone"
+
+      click_button "Delete my account"
+
+      expect(page).to have_content "Your account was deleted. Sorry to see you go."
+      expect { Account.find_by!(subdomain: subdomain) }.to raise_error ActiveRecord::RecordNotFound
+      expect { Apartment::Tenant.switch(subdomain) }.to raise_error Apartment::SchemaNotFound
+    end
+
+    scenario "has a menu item to edit account" do
+      sign_in_user(owner, subdomain: subdomain)
+
+      within ".nav-user" do
+        expect(page).to have_content "Edit Account"
+      end
+    end
+  end
+
+  context "as a regular user of an account" do
+    before(:each) do
+      Apartment::Tenant.switch(subdomain)
+
+      user = create(:user)
+      sign_in_user(user, subdomain: subdomain)
+    end
+
+    scenario "the account cannot be deleted" do
+      expect {
+        visit edit_account_url(subdomain: subdomain)
+      }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    scenario "does not have a menu item to edit account" do
+      within ".nav-user" do
+        expect(page).to have_no_content "Edit Account"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've gotten a few support requests of people trying out the app asking us to delete their account. They should be able to do this themselves :)

![screen shot 2014-08-10 at 15 39 57](https://cloud.githubusercontent.com/assets/749864/3869515/2e903508-2094-11e4-81be-f8c3aa2e1da9.png)

@dkhgh do you think this is clear enough to indicate that the entire tenant/subdomain will be deleted or should we tweak the copy a bit?
