### PR TITLE
Tag float fix

### DIFF
--- a/app/assets/stylesheets/_progress-bars.scss
+++ b/app/assets/stylesheets/_progress-bars.scss
@@ -1,18 +1,22 @@
-.activities {
-  margin-bottom: 5px;
-  text-align: center;
+.activities-overview {
+  clear: both;
 
-  li {
-    display: inline-block;
-    padding-right: 5px;
+  .activities {
+    margin-bottom: 5px;
+    text-align: center;
 
-    @include media($medium-screen) {
-      display: table-cell;
-      width: 1%;
-      border-bottom: none;
-      text-align: center;
-      padding: 11px 5px;
-      white-space: nowrap;
+    li {
+      display: inline-block;
+      padding-right: 5px;
+
+      @include media($medium-screen) {
+        display: table-cell;
+        width: 1%;
+        border-bottom: none;
+        text-align: center;
+        padding: 11px 5px;
+        white-space: nowrap;
+      }
     }
   }
 }


### PR DESCRIPTION
Added a `clear: both;` to `.activities-overview` to force it below the tags.

![screenshot 2014-12-08 12 06 01](https://cloud.githubusercontent.com/assets/816517/5343241/a81fa402-7ed2-11e4-8d33-c1a109802494.png)
