### PR TITLE
Fix tag overflow

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -85,6 +85,10 @@ $(document).ready(function(){
     new Tagger($(".taggable"));
   }
 
+  if ($('.tags-list').length > 0) {
+    new TagExpander();
+  }
+
   $('#entry_description').atwho({
     at: '#',
     data: $('#entry_description').data('data')

--- a/app/assets/javascripts/tag_expander.js.coffee
+++ b/app/assets/javascripts/tag_expander.js.coffee
@@ -1,0 +1,40 @@
+class window.TagExpander
+
+  constructor: ->
+    @all_tags = $('.tag')
+    @assess_tags()
+    $(window).resize => @assess_tags()
+    $('#more-tags').click => @_show_all()
+
+  assess_tags: ->
+    @_show(0)
+
+    if $(window).width() >= 1088
+      if @all_tags.length > 10
+        @_show(10)
+        @_show_more_link(true)
+      else
+        @_show_all()
+
+    else if $(window).width() >= 640
+      if @all_tags.length > 5
+        @_show(5)
+        @_show_more_link(true)
+      else
+        @_show_all()
+
+  # private
+
+  _show: (num) ->
+    $(".tags-list a").removeClass 'show'
+    $(".tags-list a:lt(#{num})").addClass 'show'
+
+  _show_all: ->
+    @_show(@all_tags.length)
+    @_show_more_link(false)
+
+  _show_more_link: (show) ->
+    if show
+      $('#more-tags').addClass 'show'
+    else
+      $('#more-tags').removeClass 'show'

--- a/app/assets/stylesheets/_projects.css.scss
+++ b/app/assets/stylesheets/_projects.css.scss
@@ -9,6 +9,7 @@
   }
 
   li, a {
+    display: none;
     float:left;
     height:24px;
     line-height:24px;
@@ -25,6 +26,13 @@
     text-decoration:none;
     border-bottom-right-radius:4px;
     border-top-right-radius:4px;
+
+    &.show {
+      display: block;
+      li {
+        display: block;
+      }
+    }
 
     &:before {
       content:"";

--- a/app/views/projects/_project_detail.html.erb
+++ b/app/views/projects/_project_detail.html.erb
@@ -8,6 +8,9 @@
     <% project.tags.each do |tag| %>
       <%= link_to tag_path(tag) do %><li class="tag"><%= tag.name %></li><% end %>
     <% end %>
+    <a href="#" id="more-tags">
+      <li><%= t("tags.show_more") %></li>
+    </a>
   </ul>
 
   <div class="activities-overview">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,3 +168,4 @@ en:
       hours: Hours
       category: Category
       tags: Tags
+    show_more: show more...


### PR DESCRIPTION
I think I've got a fix going for the tag overflow problem. I used browser width 1088px and 640px as breakpoints to show 10 and 5 tags respectively. Then I added a "show all" link. I also changed where the margin was placed to properly space the tags when it goes to multiple lines. Let me know if you have any comments!

10 tags:

![screenshot 2014-12-09 21 35 32](https://cloud.githubusercontent.com/assets/816517/5370185/e7801b20-7fec-11e4-9472-f45eb0d2c074.png)

10 tags expanded:

![screenshot 2014-12-09 21 35 36](https://cloud.githubusercontent.com/assets/816517/5370188/f42ffcaa-7fec-11e4-9eca-826a806bba58.png)

5 tags:

![screenshot 2014-12-09 21 35 55](https://cloud.githubusercontent.com/assets/816517/5370191/fe0d56e6-7fec-11e4-819d-459dee15d75c.png)

5 tags expanded:

![screenshot 2014-12-09 21 35 59](https://cloud.githubusercontent.com/assets/816517/5370198/0594d790-7fed-11e4-83d8-bd6a5b12de8f.png)
