### PR TITLE
Fix flash alerts

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -148,6 +148,10 @@ h1 {
   @include flash($notice-color);
 }
 
+#flash_alert {
+  @include flash($alert-color);
+}
+
 .hide-for-mobile {
   @media screen and (max-width: $medium-screen) {
     display: none;
@@ -158,10 +162,6 @@ h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 0.9em;
-}
-
-#flash_notice {
-  @include flash($notice-color);
 }
 
 .chart {


### PR DESCRIPTION
I noticed the flash messages were looking a little funny on the sign up page:

![screenshot 2014-12-12 10 46 57](https://cloud.githubusercontent.com/assets/816517/5414481/53a10e52-81ed-11e4-9ba2-73ab0014f271.png)

So I updated the stylesheet to include the styling that was already in there for flash messages:

![screenshot 2014-12-12 10 50 31](https://cloud.githubusercontent.com/assets/816517/5414488/67ea0954-81ed-11e4-9aa6-5f2cd2a86ddd.png)

I also saw that `#flash_notice` was defined twice with the exact same styles in the same file, so I removed the duplicate code.
