### PR TITLE
Add styles for accounts create page.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -40,7 +40,7 @@ body {
   line-height: 1.7em;
   background: #f7f6f0;
 
-  &.accounts-new {
+  &.accounts-new, &.accounts-create {
     background: image-url("sky.jpg") center center;
     background-size: cover;
     padding-top: 0;
@@ -75,7 +75,7 @@ h1 {
   padding: 25px;
   margin-bottom: 15px;
 
-  .accounts-new & {
+  .accounts-new &, .accounts-create & {
     background: transparent;
     box-shadow: none;
     color: #fff;
@@ -104,7 +104,7 @@ h1 {
   &.create {
   }
 
-  .accounts-new & {
+  .accounts-new &, .accounts-create & {
     width: 100%;
   }
 }


### PR DESCRIPTION
I noticed that if validation fails when creating an account, it shoots you to this page:

![screenshot 2014-12-23 12 33 55](https://cloud.githubusercontent.com/assets/816517/5541223/1d3604e4-8aa3-11e4-8218-8a64c85b2686.png)

So, I updated the styles to include the body class for that page as well. That way you get this:

![screenshot 2014-12-23 12 54 19](https://cloud.githubusercontent.com/assets/816517/5541234/3866bd30-8aa3-11e4-868c-46373be3926d.png)
