### PR TITLE
use apartment elevators for switching subdomains

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  before_filter :load_schema, :authenticate_user!
+  before_filter :authenticate_user!
   before_filter :configure_permitted_parameters, if: :devise_controller?
   before_filter :set_locale
 
@@ -32,17 +32,6 @@ class ApplicationController < ActionController::Base
 
   def current_account
     @current_account ||= Account.find_by(subdomain: request.subdomain)
-  end
-
-  def load_schema
-    Apartment::Tenant.switch("public")
-    return unless request.subdomain.present?
-
-    if current_account
-      Apartment::Tenant.switch(request.subdomain)
-    else
-      redirect_to root_url(subdomain: false)
-    end
   end
 
   def set_locale

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,9 @@ module Hours
   class Application < Rails::Application
     require "hours"
     require "time_series_initializer"
+    require "middleware/rescued_subdomain_elevator"
+
+    config.middleware.use Apartment::Elevators::RescuedSubdomain
 
     config.active_record.default_timezone = :utc
 
@@ -32,7 +35,7 @@ module Hours
       app.config.paths.add "app/presenters", eager_load: true
     end
 
-    # config.autoload_paths += Dir[Rails.root.join('app', 'models', '{**/}')]
+    # config.autoload_paths += Dir[Rails.root.join("app", "models", "{**/}")]
 
     # Settings in config/environments/* take precedence
     # over those specified here. Application configuration should
@@ -43,12 +46,12 @@ module Hours
     # Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding
     # time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    # config.time_zone = "Central Time (US & Canada)"
 
     # The default locale is :en and all translations
     # from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales',
-    #                                              '*.{rb,yml}').to_s]
+    # config.i18n.load_path += Dir[Rails.root.join("my", "locales",
+    #                                              "*.{rb,yml}").to_s]
     # config.i18n.default_locale = :de
     config.secret_token = ENV["SECRET_TOKEN"]
   end

--- a/lib/middleware/rescued_subdomain_elevator.rb
+++ b/lib/middleware/rescued_subdomain_elevator.rb
@@ -1,0 +1,22 @@
+require "apartment/elevators/subdomain"
+
+module Apartment
+  module Elevators
+    class RescuedSubdomain < Subdomain
+      def call(env)
+        super
+      rescue ::Apartment::SchemaNotFound
+        [302, {"Location" => root_url(env)}, []]
+      end
+
+      private
+
+      def root_url(env)
+        host = env["HTTP_HOST"]
+        scheme = env["rack.url_scheme"]
+        root_url = host.gsub("#{subdomain(host)}.", "")
+        [scheme, root_url].join("://")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is actually the preferred way to handle this, switching tenants now happens in rack middleware. The only thing that I don't really like about this approach is that we need to rescue from `Apartment::SchemaNotFound` in rack. This is fine but we don't have access to routing helpers here. I'd like to figure out a way to bubble the error up to `ActionController` so   we can `rescue_from Apartment::SchemaNotFound, :redirect_to_root` in our ApplicationController, or to provide this middleware with the correct route instead of parsing it out like here.

There's an issue about this on Apartment: https://github.com/influitive/apartment/issues/184
