### PR TITLE
[READY] Maarten/fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ rvm:
 - 2.2.0
 bundler_args: --without debug development
 cache: bundler
-script:
-- bundle exec rake db:test:prepare
-- bundle exec rake
 before_script:
 - cp .sample.env .env
 - cp config/database.travis.yml config/database.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,11 @@ module Hours
     # time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
+    # Don't force available locales, i.e. in case an unsupported locale is passed
+    # just silently switch to the default language (:en) instead of throwing
+    # an error.
+    I18n.config.enforce_available_locales = false
+
     # The default locale is :en and all translations
     # from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ require "paperclip/matchers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
 
+ActiveRecord::Migration.maintain_test_schema!
+
 module Features
   # Extend this module in spec/support/features/*.rb
 end


### PR DESCRIPTION
These keep bugging me:
- [x] fix the I18n deprecation warning when running the specs
- [x] let the spec helper run migrations if necessary instead of having to do it manually