### PR TITLE
pull out signup form object

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,17 +3,16 @@ class AccountsController < ApplicationController
   before_action :authorize!, only: [:edit, :destroy]
 
   def new
-    @account = Account.new
-    @account.build_owner
+    @signup = Signup.new
   end
 
   def create
-    @account = Account.new(account_params)
-    if @account.valid?
-      Apartment::Tenant.create(@account.subdomain)
-      Apartment::Tenant.switch(@account.subdomain)
-      @account.save
-      redirect_to new_user_session_url(subdomain: @account.subdomain)
+    @signup = Signup.new(signup_params)
+    if @signup.valid?
+      Apartment::Tenant.create(@signup.subdomain)
+      Apartment::Tenant.switch(@signup.subdomain)
+      @signup.save
+      redirect_to new_user_session_url(subdomain: @signup.subdomain)
     else
       render action: "new"
     end
@@ -30,13 +29,10 @@ class AccountsController < ApplicationController
 
   private
 
-  def account_params
-    params.require(:account)
-          .permit(:subdomain,
-                  owner_attributes: [
-                    :first_name, :last_name, :email,
-                    :password, :password_confirmation]
-                 )
+  def signup_params
+    params.require(:signup)
+          .permit(:subdomain, :first_name, :last_name, :email,
+                    :password, :password_confirmation)
   end
 
   def authorize!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -24,8 +24,6 @@ class Account < ActiveRecord::Base
 
   has_many :users, inverse_of: :organization
 
-  accepts_nested_attributes_for :owner
-
   private
 
   def downcase_subdomain

--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -1,0 +1,55 @@
+class Signup
+  include ActiveModel::Model
+
+  attr_accessor :first_name,
+    :last_name,
+    :email,
+    :password,
+    :password_confirmation,
+    :subdomain,
+    :user,
+    :account
+
+  validate :validate_children
+
+  def initialize(*)
+    super
+    build_children
+  end
+
+  def save
+    if valid?
+      ActiveRecord::Base.transaction do
+        account.save!
+        user.save!
+      end
+    end
+  end
+
+  private
+
+  def build_children
+    @user = User.new(first_name: first_name,
+                     last_name: last_name,
+                     email: email,
+                     password: password,
+                     password_confirmation: password_confirmation)
+    @account = Account.new(subdomain: subdomain, owner: @user)
+  end
+
+  def validate_children
+    if user.invalid?
+      promote_errors(user)
+    end
+
+    if account.invalid?
+      promote_errors(account)
+    end
+  end
+
+  def promote_errors(child)
+    child.errors.each do |attr, val|
+      errors.add(attr, val)
+    end
+  end
+end

--- a/app/views/accounts/new.html.haml
+++ b/app/views/accounts/new.html.haml
@@ -1,16 +1,15 @@
 .container
   %h1 Free Trial
   %title= title
-  = simple_form_for(@account) do |f|
+  = simple_form_for(@signup, url: accounts_path) do |f|
     = f.error_notification
     .form-inputs
-      = f.simple_fields_for :owner do |o|
-        = o.input :first_name, required: true, label: false, placeholder: t("account.first_name")
-        = o.input :last_name, required: true, label: false, placeholder: t("account.last_name")
-        = o.input :email, required: true, label: false, placeholder: t("account.email")
-        = o.input :password, required: true, label: false, placeholder: t("account.password")
-        = o.input :password_confirmation, required: true, label: false, placeholder: t("account.repeat_password")
+      = f.input :first_name, required: true, label: false, placeholder: t("account.first_name")
+      = f.input :last_name, required: true, label: false, placeholder: t("account.last_name")
+      = f.input :email, required: true, label: false, placeholder: t("account.email")
+      = f.input :password, required: true, label: false, placeholder: t("account.password")
+      = f.input :password_confirmation, required: true, label: false, placeholder: t("account.repeat_password")
       = f.input :subdomain, :required => true, label: false, placeholder: t("account.subdomain")
-      = f.button :submit, data: { disable_with: t("loader.saving") }
+      = f.button :submit, t("account.create"), data: { disable_with: t("loader.saving") }
   = link_to root_path do
     %p= t("account.back_to_website")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
   account:
     back_to_website: back to the website
     confirm_destroy: Are you sure you want to delete your account?
+    create: Create Account
     danger_zone: Danger Zone
     delete: Delete my account
     deleted: Your account was deleted. Sorry to see you go. :(

--- a/spec/features/visitor_creates_account_spec.rb
+++ b/spec/features/visitor_creates_account_spec.rb
@@ -32,12 +32,12 @@ feature "Account Creation" do
     visit root_url(subdomain: false)
     click_link "Free trial"
 
-    fill_in :account_owner_attributes_first_name, with: "John"
-    fill_in :account_owner_attributes_last_name, with: "Doe"
-    fill_in :account_owner_attributes_email, with: email
-    fill_in :account_owner_attributes_password, with: "secure123!@#"
-    fill_in :account_owner_attributes_password_confirmation, with: "secure123!@#"
-    fill_in :account_subdomain, with: subdomain
+    fill_in :signup_first_name, with: "John"
+    fill_in :signup_last_name, with: "Doe"
+    fill_in :signup_email, with: email
+    fill_in :signup_password, with: "secure123!@#"
+    fill_in :signup_password_confirmation, with: "secure123!@#"
+    fill_in :signup_subdomain, with: subdomain
 
     click_button "Create Account"
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -35,6 +35,5 @@ describe Account do
 
   describe "associations" do
     it { should belong_to :owner }
-    it { should accept_nested_attributes_for :owner }
   end
 end

--- a/spec/models/signup_spec.rb
+++ b/spec/models/signup_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Signup do
+  it "creates an account and a user" do
+    signup = Signup.new(signup_params)
+    signup.save
+
+    expect(signup.user.persisted?).to eq(true)
+    expect(signup.account.persisted?).to eq(true)
+  end
+
+  it "promotes errors on the child objects" do
+    signup = Signup.new(signup_params(first_name: ""))
+    signup.save
+
+    expect(signup.errors.keys).to include(:first_name)
+  end
+
+  def signup_params(overrides = {})
+    {
+      first_name: overrides[:first_name] || "John",
+      last_name: "Zoidberg",
+      email: "zoidberg@planetexpress.co.uk",
+      password: "whoop whoop whoop",
+      password_confirmation: "whoop whoop whoop",
+      subdomain: "whynotzoidberg"
+    }
+  end
+end


### PR DESCRIPTION
POC on how to eliminate `accepts_nested_attributes_for` in favor of form objects that are easier to use and test.