### PR TITLE
better error handling for creating clients and categories

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,17 +1,18 @@
 class CategoriesController < ApplicationController
   before_action :find_category, only: [:edit, :update]
+
   def index
-    set_index_params
+    @category = Category.new
+    @categories = Category.by_name
   end
 
   def create
-    new_category = Category.new(category_params)
-    if new_category.save
+    @category = Category.new(category_params)
+    if @category.save
       redirect_to categories_path, notice: t(:category_created)
     else
-      set_index_params
-      redirect_to categories_path,
-                  notice: new_category.errors.full_messages.join(" ")
+      @categories = Category.by_name
+      render "categories/index"
     end
   end
 
@@ -30,11 +31,6 @@ class CategoriesController < ApplicationController
 
   def find_category
     @category = Category.find(params[:id])
-  end
-
-  def set_index_params
-    @category = Category.new
-    @categories = Category.by_name
   end
 
   def category_params

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -5,17 +5,17 @@ class ClientsController < ApplicationController
   end
 
   def index
-    set_index_params
+    @client = Client.new
+    @clients = Client.by_name
   end
 
   def create
-    new_client = Client.new(client_params)
-    if new_client.save
+    @client = Client.new(client_params)
+    if @client.save
       redirect_to clients_path, notice: t(:client_created)
     else
-      set_index_params
-      redirect_to clients_path,
-                  notice: new_client.errors.full_messages.join(" ")
+      @clients = Client.by_name
+      render "clients/index"
     end
   end
 
@@ -35,11 +35,6 @@ class ClientsController < ApplicationController
 
   def resource
     @client ||= Client.find(params[:id])
-  end
-
-  def set_index_params
-    @client = Client.new
-    @clients = Client.by_name
   end
 
   def client_params

--- a/spec/features/user_manages_categories_spec.rb
+++ b/spec/features/user_manages_categories_spec.rb
@@ -17,7 +17,7 @@ feature "User manages categories" do
   scenario "creates a category with a duplicate name" do
     create(:category, name: "duplicate name")
     create_category("Duplicate name")
-    expect(page).to have_content("Name has already been taken")
+    expect(page).to have_content("has already been taken")
   end
 
   scenario "displays a list of categories" do


### PR DESCRIPTION
The `set_index_params` was actually not necessary since we were redirecting, but now we're just displaying the objects own error.