### PR TITLE
fixed filters jumping to middle

### DIFF
--- a/app/assets/stylesheets/_billables.scss
+++ b/app/assets/stylesheets/_billables.scss
@@ -1,6 +1,7 @@
 .billables {
   @include span-columns(12);
   overflow: auto;
+  display: table;
   .sidebar {
     @include media($laptop-screen) {
       @include span-columns(3);


### PR DESCRIPTION
changed .billables display to table, fixed the filtes from jumping to centre if no billables were shown.
Used to be table-cell. Not sure why it happened or if this is the best solution.