### PR TITLE
[READY?] Entries table tweaks

### DIFF
--- a/app/assets/stylesheets/_entries.scss
+++ b/app/assets/stylesheets/_entries.scss
@@ -128,8 +128,8 @@
 }
 
 .entries-table {
-  table-layout: auto;
   line-height: 20px;
+  table-layout: auto;
 
   td,
   th {
@@ -190,13 +190,13 @@
     }
   }
 
-  .date .weekday {
+  .weekday {
     color: $medium-gray;
-    font-size: .9em;
+    font-size: 0.9em;
   }
 
   .description {
-    font-size: .9em;
+    font-size: 0.9em;
     white-space: normal;
   }
 

--- a/app/assets/stylesheets/_entries.scss
+++ b/app/assets/stylesheets/_entries.scss
@@ -128,6 +128,24 @@
 }
 
 .entries-table {
+  table-layout: auto;
+  line-height: 20px;
+
+  td,
+  th {
+    padding: 4px 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:first-child {
+      padding-left: 0;
+    }
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+
   // date
   th:nth-child(1) {
     width: 10%;
@@ -147,6 +165,7 @@
   // description
   th:nth-child(5) {
     width: 30%;
+    white-space: normal;
   }
   // actions
   th:nth-child(6) {
@@ -171,11 +190,14 @@
     }
   }
 
-  td {
-    padding: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .date .weekday {
+    color: $medium-gray;
+    font-size: .9em;
+  }
+
+  .description {
+    font-size: .9em;
+    white-space: normal;
   }
 
   .center {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -59,11 +59,11 @@ body {
   }
 }
 
-h1 {   
-  margin-bottom: 1em;    
-  text-align: center;      
- 
-  @include media($medium-screen) {   
+h1 {
+  margin-bottom: 1em;
+  text-align: center;
+
+  @include media($medium-screen) {
     text-align: inherit;
   }
 }
@@ -160,12 +160,6 @@ h1 {
   @media screen and (max-width: $medium-screen) {
     display: none;
   }
-}
-
-.table-description {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 0.9em;
 }
 
 .select2-container .select2-choice {

--- a/app/views/entries/_entries_table.html.haml
+++ b/app/views/entries/_entries_table.html.haml
@@ -28,5 +28,6 @@
               = link_to t('entries.index.edit'), edit_entry_path(entry)
               |
               = link_to t('entries.index.delete'), entry, method: :delete, class: "destroy", data: { confirm: t(:confirm) }
-          %td.changes.right.hide-for-mobile = link_to t('entries.index.changes'), entry_audits_path(entry) if entry.audits.any?
+          %td.changes.right.hide-for-mobile
+            = link_to t('entries.index.changes'), entry_audits_path(entry) if entry.audits.count > 1
 = paginate @entries

--- a/app/views/entries/_entries_table.html.haml
+++ b/app/views/entries/_entries_table.html.haml
@@ -13,18 +13,20 @@
     - @entries.each do |entry|
       - localized_cache cache_key_for_current_user(entry) do
         %tr.info-row
-          %td= l(entry.date)
-          %td= link_to entry.project.name, entry.project
-          %td.center= entry.hours
-          %td.hide-for-mobile
+          %td.date
+            %div.weekday= t("weekdays." + entry.date.strftime('%A').downcase)
+            = l(entry.date)
+          %td.project= link_to entry.project.name, entry.project
+          %td.hours.center= entry.hours
+          %td.category.hide-for-mobile
             %span.color{:style => "background-color:#{entry.category.name.pastel_color};"}
             = entry.category.name
-          %td.hide-for-mobile.table-description
+          %td.description.hide-for-mobile
             = sanitize autolink_tags(entry.description)
           - if @user == current_user
-            %td.right
+            %td.actions.right
               = link_to t('entries.index.edit'), edit_entry_path(entry)
               |
               = link_to t('entries.index.delete'), entry, method: :delete, class: "destroy", data: { confirm: t(:confirm) }
-          %td.right= link_to t('entries.index.changes'), entry_audits_path(entry) if entry.audits.any?
+          %td.changes.right.hide-for-mobile = link_to t('entries.index.changes'), entry_audits_path(entry) if entry.audits.any?
 = paginate @entries

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,13 @@
 ---
 en:
+  weekdays:
+    monday: Monday
+    tuesday: Tuesday
+    wednesday: Wednesday
+    thursday: Thursday
+    friday: Friday
+    saturday: Saturday
+    sunday: Sunday
   audits:
     nothing: nothing
     title: Audit Log

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,13 @@
 ---
 nl:
+  weekdays:
+    monday: Maandag
+    tuesday: Dinsdag
+    wednesday: Woensdag
+    thursday: Donderdag
+    friday: Vrijdag
+    saturday: Zaterdag
+    sunday: Zondag
   audits:
     nothing: niets
     title: Audit Log


### PR DESCRIPTION
YAY OR NAY?

- [x] Show weekdays in entries table.
- [x] Only show changes (audit log) for edited entries.
- [x] Removed `table-layout: fixed` to avoid text wrapping.

Entires now take two lines, not sure if this is making the data less readable.

![screen shot 2015-02-28 at 16 07 14](https://cloud.githubusercontent.com/assets/935529/6426623/ef64e516-bf64-11e4-8dcb-7f7bfb48ab0f.png)
