### PR TITLE
localization of the csv export

### DIFF
--- a/app/models/entry_csv_generator.rb
+++ b/app/models/entry_csv_generator.rb
@@ -10,7 +10,7 @@ class EntryCSVGenerator
   end
 
   def generate
-    CSV.generate do |csv|
+    CSV.generate(options) do |csv|
       csv << @report.headers
       @report.each_row do |entry|
         csv << [
@@ -26,5 +26,13 @@ class EntryCSVGenerator
         ]
       end
     end
+  end
+
+  def options
+    return {
+      col_sep: ";"
+    } if I18n.locale.in?([:nl, :de])
+
+    CSV::DEFAULT_OPTIONS
   end
 end

--- a/app/models/report_entry.rb
+++ b/app/models/report_entry.rb
@@ -3,6 +3,10 @@ class ReportEntry < SimpleDelegator
     __getobj__.user.full_name
   end
 
+  def date
+    I18n.l __getobj__.date
+  end
+
   def project
     __getobj__.project.name
   end

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -238,6 +238,16 @@ nl:
       current_password: we hebben uw huidig wachtwoord nodig om de veranderingen te bevestigen
     update_button: Opslaan
   report:
+    headers:
+      date: Datum
+      user: Gebruiker
+      project: Project
+      category: Categorie
+      client: Klant
+      hours: Uren
+      billable: Facturabel
+      billed: Gefactureerd
+      description: Beschrijving
     filters: filters
     hours_per_day: Uren per dag
     monthly: 1 maand

--- a/spec/models/entry_csv_generator_spec.rb
+++ b/spec/models/entry_csv_generator_spec.rb
@@ -1,18 +1,23 @@
 require "spec_helper"
+require "csv"
 
 describe EntryCSVGenerator do
-  it "generates csv" do
-    first_entry = build_stubbed(:entry)
-    second_entry = build_stubbed(:entry)
-    data = [].tap do |d|
-      d << first_entry
-      d << second_entry
-    end
+  let(:first_entry) { build_stubbed(:entry) }
+  let(:second_entry) { build_stubbed(:entry) }
+  let(:generator) { EntryCSVGenerator.new([first_entry, second_entry]) }
 
-    csv = EntryCSVGenerator.new(data).generate
+  it "generates csv" do
+    csv = generator.generate
     expect(csv).to include(
       "Date,User,Project,Category,Client,Hours,Billable,Billed,Description")
     expect(csv.lines.count).to eq(3)
     expect(csv.lines.last.split(",").count).to eq(9)
+  end
+
+  it "localizes the separator" do
+    I18n.locale = :nl
+    expect(generator.options).to include(col_sep: ";")
+    I18n.locale = I18n.default_locale
+    expect(generator.options).to include(col_sep: ",")
   end
 end

--- a/spec/models/report_entry_spec.rb
+++ b/spec/models/report_entry_spec.rb
@@ -4,8 +4,8 @@ describe ReportEntry do
   let(:entry) { create(:entry_with_client) }
   subject(:report_entry) { ReportEntry.new(entry) }
 
-  it "#date" do
-    expect(report_entry.date).to eq(entry.date)
+  it "#date localized" do
+    expect(report_entry.date).to eq(I18n.l entry.date)
   end
 
   it "#user" do


### PR DESCRIPTION
The default separator in western europe is the ';' in order to prevent collisions with the decimal separator. Dutch Excel expects it in this format as well.... :unamused: 