### PR TITLE
[READY] turn off autocomplete on billable form

### DIFF
--- a/app/views/billables/index.html.haml
+++ b/app/views/billables/index.html.haml
@@ -12,7 +12,7 @@
     - unless @entries.any?
       .info
         %p= t("info.no_billable_entries_html")
-    = form_tag("/billables", method: "post", remote: true, id: "billable-entries-form") do
+    = form_tag("/billables", method: "post", remote: true, id: "billable-entries-form", autocomplete: "off") do
       - @billable_list.clients.each do |client|
         %h1= client.name
         = render "projects", projects: client.projects


### PR DESCRIPTION
To prevent firefox from caching checkbox state. Somehow (in firefox only) it incorrectly caches the state of for example the topmost checkbox, then after billing the selected entries the newly topmost checkbox will be checked.

also see http://stackoverflow.com/questions/299811/why-does-the-checkbox-stay-checked-when-reloading-the-page