### PR TITLE
Fix bundler warning: this Gemfile contains multiple primary sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-source "https://rails-assets.org"
 
 ruby "2.2.2"
 
@@ -34,7 +33,6 @@ gem "kaminari"
 gem "select2-rails"
 gem "http_accept_language"
 gem "normalize-rails"
-gem "rails-assets-chartjs"
 gem "twitter-text" # hashtag parsing
 gem "jquery-atwho-rails", "~> 1.0.0" # autocomplete
 gem "haml-rails"
@@ -43,6 +41,10 @@ gem "paperclip", "~> 4.2"
 gem "aws-sdk", "< 2.0"
 gem "redcarpet"
 gem "holidays"
+
+source "https://rails-assets.org" do
+  gem "rails-assets-chartjs"
+end
 
 # caching
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,7 @@ DEPENDENCIES
   pry-rails
   rack-timeout
   rails (~> 4.2.0)
-  rails-assets-chartjs
+  rails-assets-chartjs!
   rails_12factor
   recipient_interceptor
   redcarpet


### PR DESCRIPTION
The following warning is occured when I execute *bundle install* .

```
Warning: this Gemfile contains multiple primary sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. 
To resolve this warning, use a block to indicate which gems should come from the secondary source.
To upgrade this warning to an error, run `bundle config disable_multisource true`.
```