### PR TITLE
Use before_action instead of before_filter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,10 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :reset_session
-  before_filter :load_schema, unless: -> { Hours.single_tenant_mode? }
-  before_filter :authenticate_user!
-  before_filter :configure_permitted_parameters, if: :devise_controller?
-  before_filter :set_locale
+  before_action :load_schema, unless: -> { Hours.single_tenant_mode? }
+  before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_locale
 
   protected
 


### PR DESCRIPTION
The reason for this change is that before_filter is not recommended since Rails 4.2.0.