### PR TITLE
Fix for heroku deployment issue with pgbackups deprication.

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,6 @@
   },
   "addons": [
     "heroku-postgresql",
-    "pgbackups",
     "memcachier",
     "papertrail",
     "sendgrid"


### PR DESCRIPTION
The PG backup add on for heroku is depricated and moved to Heroku postgres.
As described here - https://devcenter.heroku.com/changelog-items/623

This is fixable by removing the pgbackups from the addons in app.json.