### PR TITLE
Use Timeout::Error instead of TimeoutError

### DIFF
--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -16,7 +16,7 @@ HTTP_ERRORS = [Timeout::Error,
                Net::HTTPHeaderSyntaxError,
                Net::ProtocolError]
 
-SMTP_SERVER_ERRORS = [TimeoutError,
+SMTP_SERVER_ERRORS = [Timeout::Error,
                       IOError,
                       Net::SMTPUnknownError,
                       Net::SMTPServerBusy,


### PR DESCRIPTION
This is due to receiving a deprecation warning:

```
/Users/takiy33/.ghq/github.com/takiy33/Hours/config/initializers/errors.rb:19: warning: constant ::TimeoutError is deprecated
```