### PR TITLE
Add lambda in factories_spec error messages

### DIFF
--- a/spec/models/factories_spec.rb
+++ b/spec/models/factories_spec.rb
@@ -4,7 +4,9 @@ describe 'factories' do
       factory = build(factory_name)
 
       if factory.respond_to?(:valid?)
-        expect(factory).to be_valid, factory.errors.full_messages.join(',')
+        expect(factory).to be_valid, lambda {
+          factory.errors.full_messages.join(',')
+        }
       end
     end
   end


### PR DESCRIPTION
When factories fails we don't see any error message : 

```ruby
Failures:

  1) factories request factory is valid
     Failure/Error: expect(factory).to be_valid, factory.errors.full_messages.join(',')
     # ./spec/models/factories_spec.rb:8:in `block (3 levels) in <top (required)>'
```

After this fix : 

```ruby
Failures:

  1) factories request factory is valid
     Failure/Error: expect(factory).to be_valid, lambda { factory.errors.full_messages.join(',') }
       Apartments doit être rempli(e)
     # ./spec/models/factories_spec.rb:7:in `block (3 levels) in <top (required)>'
```

See : https://github.com/thoughtbot/factory_girl/wiki/Testing-all-Factories-(with-RSpec)