### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As we're using Hours we're constantly thinking of ways to improve it and we'd lo
 System Dependencies
 -------------------
 
-- Ruby 2.2.3 (install with [rbenv](https://github.com/sstephenson/rbenv))
+- Ruby 2.3.0 (install with [rbenv](https://github.com/sstephenson/rbenv))
 - Rubygems
 - Bundler (`gem install bundler`)
 - PostgreSQL


### PR DESCRIPTION
I fix typo in README.md.
Ruby has been updated 2.3.0 at #365.