### PR TITLE
Display localized text corectrlly on landing page

### DIFF
--- a/app/views/pages/landing.html.haml
+++ b/app/views/pages/landing.html.haml
@@ -10,7 +10,7 @@
           .flip
             .flip-front
               %span
-                = t("pages.free_trial")
+                = raw t("pages.free_trial")
             .flip-back
               %span
                 Free

--- a/app/views/pages/landing.html.haml
+++ b/app/views/pages/landing.html.haml
@@ -10,7 +10,7 @@
           .flip
             .flip-front
               %span
-                = raw t("pages.free_trial")
+                = t("pages.free_trial")
             .flip-back
               %span
                 Free

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,5 +284,5 @@ en:
     not_archived: Not Archived
   pages:
     slogan: Time registration that doesn't suck.
-    free_trial: Free<br/> triall
+    free_trial_html: Free<br/> triall
     prices: Prices

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -284,5 +284,5 @@ pl:
     not_archived: Nie zarchiwizowane
   pages:
     slogan: Rejestracja czasu, która nie zawodzi
-    free_trial: "Darmowy <br/>okres próbny"
+    free_trial_html: "Darmowy <br/>okres próbny"
     prices: Ceny


### PR DESCRIPTION
I noticed problem on landing page with translation files, to be more pricise problem was on **Free Trial** span. As you can see on image...
<img width="1268" alt="landing" src="https://cloud.githubusercontent.com/assets/7427365/13554573/a4c8df8c-e3ab-11e5-9898-c5b91d53608a.png">

Problem is that there is html tags in this translation, when you want to used html tag in your translations, you must call translation method like this:
`<%=  raw t('translation') %>` 

Here is more info on rails docs:
http://guides.rubyonrails.org/i18n.html#using-safe-html-translations