### PR TITLE
Add missing entry filter tests

### DIFF
--- a/app/models/entry_filter.rb
+++ b/app/models/entry_filter.rb
@@ -13,13 +13,9 @@ class EntryFilter
   ].freeze
 
   attr_accessor(*KEYS)
-  attr_reader :projects, :clients, :users
 
   def initialize(params = {})
     super(Params.new(params))
-    @clients = Client.by_name
-    @projects = Project.by_name
-    @users = User.by_name
   end
 
   def billed_options
@@ -49,6 +45,18 @@ class EntryFilter
 
   def to_date
     DateTime.parse(@to_date) if @to_date.present?
+  end
+
+  def clients
+    @clients ||= Client.by_name
+  end
+
+  def users
+    @users ||= User.by_name
+  end
+
+  def projects
+    @projects ||= Project.by_name
   end
 end
 

--- a/spec/models/entry_filter_spec.rb
+++ b/spec/models/entry_filter_spec.rb
@@ -7,20 +7,20 @@ describe EntryFilter do
 
   it "#clients" do
     filter = EntryFilter.new
-
-    expect(filter.clients).to eq(Client.by_name)
+    expect(Client).to receive(:by_name)
+    filter.clients
   end
 
   it "#users" do
     filter = EntryFilter.new
-
-    expect(filter.users).to eq(User.by_name)
+    expect(User).to receive(:by_name)
+    filter.users
   end
 
   it "#projects" do
     filter = EntryFilter.new
-
-    expect(filter.projects).to eq(Project.by_name)
+    expect(Project).to receive(:by_name)
+    filter.projects
   end
 
   it "billed_options" do

--- a/spec/models/entry_filter_spec.rb
+++ b/spec/models/entry_filter_spec.rb
@@ -7,20 +7,32 @@ describe EntryFilter do
 
   it "#clients" do
     filter = EntryFilter.new
-    expect(Client).to receive(:by_name)
-    filter.clients
+
+    client1 = create(:client, name: "Zack")
+    client2 = create(:client, name: "Andy")
+    clients = [client2, client1]
+
+    expect(filter.clients).to eq clients
   end
 
   it "#users" do
     filter = EntryFilter.new
-    expect(User).to receive(:by_name)
-    filter.users
+
+    user1 = create(:user, last_name: "Simpson")
+    user2 = create(:user, last_name: "Burns")
+    users = [user2, user1]
+
+    expect(filter.users).to eq users
   end
 
   it "#projects" do
     filter = EntryFilter.new
-    expect(Project).to receive(:by_name)
-    filter.projects
+
+    project1 = create(:project, name: "Learning Spaces")
+    project2 = create(:project, name: "Defacto")
+    projects = [project2, project1]
+
+    expect(filter.projects).to eq projects
   end
 
   it "#billed_options" do

--- a/spec/models/entry_filter_spec.rb
+++ b/spec/models/entry_filter_spec.rb
@@ -8,31 +8,28 @@ describe EntryFilter do
   it "#clients" do
     filter = EntryFilter.new
 
-    client1 = create(:client, name: "Zack")
-    client2 = create(:client, name: "Andy")
-    clients = [client2, client1]
+    create(:client, name: "Zack")
+    create(:client, name: "Andy")
 
-    expect(filter.clients).to eq clients
+    expect(filter.clients).to eq Client.by_name
   end
 
   it "#users" do
     filter = EntryFilter.new
 
-    user1 = create(:user, last_name: "Simpson")
-    user2 = create(:user, last_name: "Burns")
-    users = [user2, user1]
+    create(:user, last_name: "Simpson")
+    create(:user, last_name: "Burns")
 
-    expect(filter.users).to eq users
+    expect(filter.users).to eq User.by_name
   end
 
   it "#projects" do
     filter = EntryFilter.new
 
-    project1 = create(:project, name: "Learning Spaces")
-    project2 = create(:project, name: "Defacto")
-    projects = [project2, project1]
+    create(:project, name: "Learning Spaces")
+    create(:project, name: "Defacto")
 
-    expect(filter.projects).to eq projects
+    expect(filter.projects).to eq Project.by_name
   end
 
   it "#billed_options" do

--- a/spec/models/entry_filter_spec.rb
+++ b/spec/models/entry_filter_spec.rb
@@ -23,12 +23,54 @@ describe EntryFilter do
     filter.projects
   end
 
-  it "billed_options" do
+  it "#billed_options" do
     filter = EntryFilter.new
 
     expect(filter.billed_options).to eq([
       [I18n.t("entry_filters.not_billed"), false],
       [I18n.t("entry_filters.billed"), true]
     ])
+  end
+
+  it "#billable_options" do
+    filter = EntryFilter.new
+
+    expect(filter.billable_options).to eq([
+      [I18n.t("entry_filters.not_billable"), false],
+      [I18n.t("entry_filters.billable"), true]
+    ])
+  end
+
+  it "#archived_options" do
+    filter = EntryFilter.new
+
+    expect(filter.archived_options).to eq([
+      [I18n.t("entry_filters.not_archived"), false],
+      [I18n.t("entry_filters.archived"), true]
+    ])
+  end
+
+  describe "#from_date" do
+    it "is a DateTime" do
+      filter = EntryFilter.new(from_date: "14/10/2017")
+      expect(filter.from_date).to eq DateTime.parse("14/10/2017")
+    end
+
+    it "is nil when there is no from_date" do
+      filter = EntryFilter.new
+      expect(filter.from_date).to be_nil
+    end
+  end
+
+  describe "#to_date" do
+    it "is a DateTime" do
+      filter = EntryFilter.new(to_date: "14/10/2017")
+      expect(filter.to_date).to eq DateTime.parse("14/10/2017")
+    end
+
+    it "is nil when there is no to_date" do
+      filter = EntryFilter.new
+      expect(filter.to_date).to be_nil
+    end
   end
 end

--- a/spec/models/entry_filter_spec.rb
+++ b/spec/models/entry_filter_spec.rb
@@ -7,27 +7,21 @@ describe EntryFilter do
 
   it "#clients" do
     filter = EntryFilter.new
-
-    create(:client, name: "Zack")
-    create(:client, name: "Andy")
+    create_list(:client, 2)
 
     expect(filter.clients).to eq Client.by_name
   end
 
   it "#users" do
     filter = EntryFilter.new
-
-    create(:user, last_name: "Simpson")
-    create(:user, last_name: "Burns")
+    create_list(:user, 2)
 
     expect(filter.users).to eq User.by_name
   end
 
   it "#projects" do
     filter = EntryFilter.new
-
-    create(:project, name: "Learning Spaces")
-    create(:project, name: "Defacto")
+    create_list(:project, 2)
 
     expect(filter.projects).to eq Project.by_name
   end

--- a/spec/models/entry_filter_spec.rb
+++ b/spec/models/entry_filter_spec.rb
@@ -26,28 +26,34 @@ describe EntryFilter do
   it "#billed_options" do
     filter = EntryFilter.new
 
-    expect(filter.billed_options).to eq([
+    billed_options = [
       [I18n.t("entry_filters.not_billed"), false],
       [I18n.t("entry_filters.billed"), true]
-    ])
+    ]
+
+    expect(filter.billed_options).to eq(billed_options)
   end
 
   it "#billable_options" do
     filter = EntryFilter.new
 
-    expect(filter.billable_options).to eq([
+    billable_options = [
       [I18n.t("entry_filters.not_billable"), false],
       [I18n.t("entry_filters.billable"), true]
-    ])
+    ]
+
+    expect(filter.billable_options).to eq(billable_options)
   end
 
   it "#archived_options" do
     filter = EntryFilter.new
 
-    expect(filter.archived_options).to eq([
+    archived_options = [
       [I18n.t("entry_filters.not_archived"), false],
       [I18n.t("entry_filters.archived"), true]
-    ])
+    ]
+
+    expect(filter.archived_options).to eq(archived_options)
   end
 
   describe "#from_date" do


### PR DESCRIPTION
`EntryFilter#clients`, `EntryFilter#users`, and `EntryFilter#projects` were easier to test when they were extracted into methods, but I'm happy to revert that change if you'd prefer to keep them in the `initialize` method.