### PR TITLE
Add the tld_length action_dispatch config

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -9,3 +9,4 @@ SINGLE_TENANT_MODE=false
 S3_BUCKET_NAME="s3_bucket_name"
 AWS_ACCESS_KEY_ID="aws_access_key_id"
 AWS_SECRET_ACCESS_KEY="aws_secret_access_key"
+TLD_LENGTH=0

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,4 +36,5 @@ Hours::Application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
 
   config.action_mailer.default_url_options = { host: "hours.dev" }
+  config.action_dispatch.tld_length = 0
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,5 +36,5 @@ Hours::Application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
 
   config.action_mailer.default_url_options = { host: "hours.dev" }
-  config.action_dispatch.tld_length = ENV["TLD_LENGTH"] || 1
+  config.action_dispatch.tld_length = ENV['TLD_LENGTH'] || 1
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,5 +36,5 @@ Hours::Application.configure do
   config.action_controller.action_on_unpermitted_parameters = :raise
 
   config.action_mailer.default_url_options = { host: "hours.dev" }
-  config.action_dispatch.tld_length = 0
+  config.action_dispatch.tld_length = ENV["TLD_LENGTH"] || 1
 end


### PR DESCRIPTION
Who uses linux and don't have an alternative like pow.

In the development environment the best option is to pass this value to the config.action_dispatch.tld_length.

Reference Link: https://github.com/rails/rails/issues/12438#issuecomment-25875656