### PR TITLE
Fix Error When Using Create_User Rake Task

### DIFF
--- a/lib/tasks/create_user.rake
+++ b/lib/tasks/create_user.rake
@@ -1,3 +1,5 @@
+require 'io/console'
+
 desc "Create a first user for single tenant mode"
 task :create_user => :environment do
   if Hours.single_tenant_mode?


### PR DESCRIPTION
This PR fixes the exception that occurs when trying to create a user with script in create_user.rake for single tenant mode