### PR TITLE
Update user page with total hours and join date

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,7 +1,24 @@
 .title-container {
   @include clearfix;
 
-  h1 {
-    float: left;
+  .user-detail-container {
+    .user-title {
+      float: left;
+      margin-bottom: 0;
+    }
+  }
+}
+
+.user-stats {
+  .joined-time {
+    margin-left: 0.5em;
+    font-size: 0.8rem
+  }
+
+  .total-hours {
+    float: right;
+    margin-right: 1em;
+    font-weight: bold;
+    text-align: center;
   }
 }

--- a/app/assets/stylesheets/_time_span.scss
+++ b/app/assets/stylesheets/_time_span.scss
@@ -5,7 +5,6 @@
 
   p {
     float: right;
-    // font-size: em;
     color: #ccc;
     text-transform: uppercase;
     letter-spacing: 1px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ include TimeSeriesInitializer
 class UsersController < ApplicationController
   def show
     @time_series = time_series_for(resource)
+    @entry_stats = EntryStats.new(@time_series.entries_for_time_span)
   end
 
   def index

--- a/app/views/_header.html.haml
+++ b/app/views/_header.html.haml
@@ -1,3 +1,4 @@
 .title-container
-  %h1= title
+  .user-detail-container
+    %h1.user-title= title
   = render "/time_span" if @time_series

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,9 +3,14 @@
 .outer
   .container
     = render "/header", title: @user.full_name
+    %p.user-stats
+      %span.joined-time Joined: #{@user.created_at.strftime("%B %d, %Y")}
+      %span.total-hours Total Hours Spent: #{@entry_stats.total_hours}
     .charts
       = render @time_series.chart, time_series: @time_series
     .charts
-      = render "/charts/pie_chart", title: t("charts.hours_spent_per_project"), data: EntryStats.new(@time_series.entries_for_time_span).hours_for_subject_collection(Project.all).to_json
-      = render "/charts/pie_chart", title: t("charts.hours_spent_per_category"), data: EntryStats.new(@time_series.entries_for_time_span).hours_for_subject_collection(Category.all).to_json
+      = render "/charts/pie_chart", title: t("charts.hours_spent_per_project"),
+      data: @entry_stats.hours_for_subject_collection(Project.all).to_json
+      = render "/charts/pie_chart", title: t("charts.hours_spent_per_category"),
+      data: @entry_stats.hours_for_subject_collection(Category.all).to_json
     = link_to t("users.show.entries"), user_entries_path(@user)


### PR DESCRIPTION
**Objective**
This PR updates the user page to include details about how much hours the user has in total and the date they joined Hours

**Related Issue**
See related issue [here](https://github.com/DefactoSoftware/Hours/issues/476)

**Screenshots**
Total hours change with filter, just like the charts.
<img width="1440" alt="screen shot 2019-02-26 at 9 25 00 pm" src="https://user-images.githubusercontent.com/20444781/53443933-20282b00-3a0d-11e9-92f3-872c5270494b.png">
<img width="1440" alt="screen shot 2019-02-26 at 9 24 41 pm" src="https://user-images.githubusercontent.com/20444781/53443949-2b7b5680-3a0d-11e9-95ba-5019df5f8f50.png">
<img width="1440" alt="screen shot 2019-02-26 at 9 24 20 pm" src="https://user-images.githubusercontent.com/20444781/53443965-37ffaf00-3a0d-11e9-8c4d-c07bd950129d.png">
