### PR TITLE
Remove capybara-webkit as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara-webkit", ">= 1.0.0"
+  gem 'capybara', '~> 3.16', '>= 3.16.1'
   gem "database_cleaner"
   gem "launchy"
   gem "shoulda-matchers", "~> 2.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,15 +615,14 @@ GEM
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
     builder (3.2.3)
-    capybara (2.3.0)
-      mime-types (>= 1.16)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
-    capybara-webkit (1.2.0)
-      capybara (>= 2.0.2, < 2.4.0)
-      json
+    capybara (3.16.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     climate_control (0.2.0)
     coderay (1.1.2)
     coffee-rails (4.0.1)
@@ -709,7 +708,6 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.1.0)
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -800,6 +798,7 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     redcarpet (3.4.0)
+    regexp_parser (1.4.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -889,8 +888,8 @@ GEM
     webmock (1.18.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -906,7 +905,7 @@ DEPENDENCIES
   bitters
   bourbon
   brakeman
-  capybara-webkit (>= 1.0.0)
+  capybara (~> 3.16, >= 3.16.1)
   coffee-rails
   dalli
   database_cleaner
@@ -967,4 +966,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ System Dependencies
 - PostgreSQL
 - qmake (`brew install qt`) or read extensive instructions [here](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit)
 - memcached (`brew install memcached`, an older version ships with OSX)(optional)
+- imagemagick (`brew install imagemagick`)
 
 Getting Started
 ---------------


### PR DESCRIPTION
This PR removes capybara-webkit as a project dependency. This is
because the gem doesn't appear to be used any where in the test code.

This commit also add imagemagick to the README because it is a project
dependency.

It addresses:
- https://github.com/DefactoSoftware/Hours/issues/489 
- https://github.com/DefactoSoftware/Hours/issues/488