### PR TITLE
Speed up entry creation (#400)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,6 +6,8 @@ class ProjectsController < ApplicationController
     @hours_entry = Hour.new
     @mileages_entry = Mileage.new
     @activities = Hour.by_last_created_at.limit(30)
+    @last_hour_logged = current_user.hours.by_last_updated_at.first
+    @last_mileage_logged = current_user.mileages.by_last_updated_at.first
   end
 
   def show

--- a/app/models/hour.rb
+++ b/app/models/hour.rb
@@ -27,6 +27,7 @@ class Hour < Entry
   accepts_nested_attributes_for :taggings
 
   scope :by_last_created_at, -> { order("created_at DESC") }
+  scope :by_last_updated_at, -> { order("updated_at DESC") }
   scope :by_date, -> { order("date DESC") }
   scope :billable, -> { where("billable").joins(:project) }
   scope :with_clients, -> {

--- a/app/models/mileage.rb
+++ b/app/models/mileage.rb
@@ -14,6 +14,7 @@
 
 class Mileage < Entry
   scope :by_last_created_at, -> { order("created_at DESC") }
+  scope :by_last_updated_at, -> { order("updated_at DESC") }
   scope :by_date, -> { order("date DESC") }
   scope :billable, -> { where("billable").joins(:project) }
   scope :with_clients, -> {

--- a/app/views/application/_hours_entry_form.html.haml
+++ b/app/views/application/_hours_entry_form.html.haml
@@ -1,10 +1,10 @@
 = simple_form_for @hours_entry do |f|
   = f.error_notification
-  = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project")
-  = f.association :category, required: true, collection: Category.by_name, label: false, placeholder: t("entries.index.category")
-  = f.input :value, required: true, label: false, placeholder: t("entries.index.hours")
+  = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project"), selected: @last_hour_logged&.project_id || @hours_entry&.project_id
+  = f.association :category, required: true, collection: Category.by_name, label: false, placeholder: t("entries.index.category"), selected: @last_hour_logged&.category_id || @hours_entry&.category_id
+  = f.input :value, required: true, label: false, placeholder: t("entries.index.hours"), input_html: { value: @last_hour_logged&.value || @hours_entry&.value }
   = f.input :date, required: true, as: :string, input_html: { value: (@hours_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false
   .taggable
-    = f.input :description, input_html: { data: { data: Tag.list }, autocomplete: :off }, label: false, autocomplete: "off", placeholder: t("entries.index.description")
+    = f.input :description, input_html: { data: { data: Tag.list }, autocomplete: :off }, label: false, autocomplete: "off", placeholder: t("entries.index.description"), input_html: { value: @last_hour_logged&.description || @hours_entry&.description }
     %span.background-highlighter
   = f.button :submit, data: { disable_with: t("loader.saving") }

--- a/app/views/application/_mileages_entry_form.html.haml
+++ b/app/views/application/_mileages_entry_form.html.haml
@@ -1,6 +1,6 @@
 = simple_form_for @mileages_entry do |f|
   = f.error_notification
-  = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project")
-  = f.input :value, required: true, as: :integer, label:false, placeholder: t("entries.index.mileages")
+  = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project"), selected: @last_mileage_logged&.project_id || @mileages_entry&.project_id 
+  = f.input :value, required: true, as: :integer, label:false, placeholder: t("entries.index.mileages"), input_html: { value: @last_mileage_logged&.value || @mileages_entry&.value }
   = f.input :date, required: true, as: :string, input_html: { value: (@mileages_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false
   = f.button :submit, data: { disable_with: t("loader.saving") }

--- a/spec/models/hour_spec.rb
+++ b/spec/models/hour_spec.rb
@@ -90,6 +90,16 @@ describe Hour do
     end
   end
 
+  describe "#by_last_updated_at" do
+    it "orders the entries by updated_at" do
+      initial_hour = create(:hour)
+      Timecop.scale(600)
+      create(:hour)
+      initial_hour.update_attribute(:value, 2)
+      expect(Hour.by_last_updated_at.first).to eq(initial_hour)
+    end
+  end
+
   describe "#by_date" do
     it "orders the entries by date (latest first)" do
       create(:hour, date: Date.new(2014, 01, 01))

--- a/spec/models/mileage_spec.rb
+++ b/spec/models/mileage_spec.rb
@@ -46,6 +46,16 @@ describe Mileage do
     end
   end
 
+  describe "#by_last_updated_at" do
+    it "orders the entries by updated_at" do
+      initial_hour = create(:mileage)
+      Timecop.scale(600)
+      create(:mileage)
+      initial_hour.update_attribute(:value, 2)
+      expect(Mileage.by_last_updated_at.first).to eq(initial_hour)
+    end
+  end
+
   describe "by_date" do
     it "orders the entries by date (latest first)" do
       create(:mileage, date: Date.new(2014, 01, 01))


### PR DESCRIPTION
**What does this PR do?**
- [x] Fetches the last hour and mileage logged by a user
- [x] Persist the last hour and mileage on the hours and mileages creation form respectively
- [x] Write Tests for modifications, adding model tests for scopes added

**Description of Task to be completed?**
>- https://github.com/DefactoSoftware/Hours/issues/400#issue-208948015
>- https://github.com/DefactoSoftware/Hours/issues/400#issuecomment-281145723

**How should this be manually tested?**
- Running the application tests, making sure none fails including the newly added model tests.
- Ensuring that the `hours` and `kilometers` creation forms are prefilled with last created or updated `hour` or `kilometer` respectively.
- Also, ensure that on an attempt to edit an `hour` or `kilometer` entry, the selected entry is properly updated

**Any background context you want to provide?**
- None

**What are the relevant issues?**
- https://github.com/DefactoSoftware/Hours/issues/400

**Screenshots (if appropriate)**
- 
<img width="1440" alt="Screen Shot 2019-04-18 at 12 32 56 AM" src="https://user-images.githubusercontent.com/12856872/56327409-2798c480-6172-11e9-85d8-a0e94a11a7a9.png">

- 
<img width="1440" alt="Screen Shot 2019-04-18 at 12 32 58 AM" src="https://user-images.githubusercontent.com/12856872/56327422-341d1d00-6172-11e9-9681-c942513e3403.png">

**Questions:**
- N/A
