### PR TITLE
(WIP) Add timer functionality for an hour entry (#492)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,133 @@ $(document).ready(function() {
     on('click', 'div', function(e) { e.stopPropagation();
   });
 
+  // Timer Feature Starts
+  var container = $('.hour_timer_value_div');
+  var interval;
+  var isStopped = true;
+  var entry_type_option = 'manual'
+  var currentDate = function () {
+    // get client's current date
+    var date = new Date();
+    var utc = date.getTime() + (date.getTimezoneOffset() * 60000);
+    var newDate = new Date(utc + 3600000)
+    return newDate;
+  };
+  var StartDate = currentDate();
+  
+  var countdown = function () {
+    var currentNewDate = currentDate();
+    
+    // difference of dates
+    var difference = currentNewDate - StartDate;
+
+    if (isStopped) {
+      // stop timer
+      clearInterval(interval);
+      StartDate = currentDate();
+      return;
+    }
+  
+    // basic math variables
+    var _second = 1000,
+      _minute = _second * 60,
+      _hour = _minute * 60,
+      _day = _hour * 24;
+    
+    // calculate dates
+    var hours = Math.floor(difference / _hour),
+      minutes = Math.floor((difference % _hour) / _minute),
+      seconds = Math.floor((difference % _minute) / _second);
+    
+    // fix dates so that it will show two digets
+    hours = (String(hours).length >= 2) ? hours : '0' + hours;
+    minutes = (String(minutes).length >= 2) ? minutes : '0' + minutes;
+    seconds = (String(seconds).length >= 2) ? seconds : '0' + seconds;
+  
+    // set to DOM
+    container.find('.hours').text(hours);
+    container.find('.minutes').text(minutes);
+    container.find('.seconds').text(seconds);
+
+    interval = setInterval(countdown, 1000);
+  }
+
+  var resetTimerValuDiv = function() {
+    // unset from DOM
+    container.find('.hours').text('00');
+    container.find('.minutes').text('00');
+    container.find('.seconds').text('00');
+  }
+
+  var roundToHour = function(date) {
+    p = 60 * 60 * 1000; // milliseconds in an hour
+    return new Date(Math.round(date.getTime() / p ) * p);
+  }
+
+  $('.btn-group .switch').on('click', 'span', function(event) {
+    event.preventDefault();
+    var input = $(this).parent().siblings('.hour_entry_type_option').find('input[type=hidden]');
+    if (input.length > 0) {
+      if ($(this).attr('data-value').toString() === 'manual') {
+        // set entry_type_option to timer
+        $(this).attr('data-value', 'timer');
+        entry_type_option = 'timer'
+      } else if (($(this)).attr('data-value').toString() === 'timer') {
+        // set entry_type_option to manual
+        $(this).attr('data-value', 'manual');
+        entry_type_option = 'manual'
+        // set isStopped true to stop timer and reset timer div values
+        isStopped = true;
+        resetTimerValuDiv();
+      }
+
+      $('.hour_date').toggle();
+      $('.hour_value').toggle();
+
+      $('.hour_timer_value_div').toggle();
+
+      $('#hours-tab input[type=submit]').toggle();
+      $('#hours-tab .timer-btn').toggle();
+
+      input.val($(this).attr('data-value').toString()).trigger('change');
+      $(this).toggleClass('timer');
+    }
+  })
+
+  $('#hours-tab .timer-btn').on('click', 'button.start-timer', function(event) {
+    event.preventDefault();
+    // start timer
+    StartDate = currentDate();
+    isStopped = false;
+    countdown();
+
+    $('.start-timer').hide();
+    $('.stop-timer').show();
+  })
+
+  $('#hours-tab #new_hour').on('submit', function(event) {
+    if (entry_type_option === 'timer') {
+      // set isStopped true to stop timer and reset timer div values
+      isStopped = true;
+      var hours = Number(container.find('.hours').text()),
+        minutes = Number(container.find('.minutes').text()),
+        seconds = Number(container.find('.seconds').text());
+      resetTimerValuDiv();
+      var today = new Date();
+      today.setHours(hours, minutes, seconds, 0);
+      var roundedHour = Number(roundToHour(today).getHours());
+      roundedHour = roundedHour <= 0 ? roundedHour + 1 : roundedHour
+
+      $('#hours-tab input#hour_value').val(roundedHour);
+      $('#hours-tab input#hour_timer_value').val(roundedHour);
+      $('.stop-timer').hide();
+      $('.start-timer').show();
+    }
+    // call the submit action of this simple_form_for -> #hours-tab #new_hour
+    $('#hours-tab #new_hour').unbind('submit').submit()
+  })
+  // Timer Feature Ends
+
   $('#hour_project_id').select2();
   $('#hour_category_id').select2();
   $('#mileage_project_id').select2();

--- a/app/assets/stylesheets/_entries.scss
+++ b/app/assets/stylesheets/_entries.scss
@@ -50,6 +50,61 @@
   .entry-tag-list {
     width: 100%;
     }
+
+  #entry_type_buttons {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 60px;
+      height: 34px;
+      margin: 0 1rem;
+
+      .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: $light-gray;
+        transition: .4s;
+        -webkit-transition: .4s;
+
+        &:before {
+          position: absolute;
+          content: "";
+          height: 26px;
+          width: 26px;
+          left: 4px;
+          bottom: 4px;
+          background-color: $base-body-color;
+          transition: .4s;
+          -webkit-transition: .4s;
+        }
+
+        &.round {
+          border-radius: 34px;
+          &:before {
+            border-radius: 50%;
+          }
+        }
+      }
+    }
+
+    .slider.timer {
+      background-color: $blue;
+    }
+
+    .slider.timer:before {
+      transform: translateX(26px);
+      -webkit-transform: translateX(26px);
+      -ms-transform: translateX(26px);
+    }
+  }
 }
 
 .edit-entry-wrapper {
@@ -222,4 +277,8 @@
   .right {
     text-align: right;
   }
+}
+
+.hour_timer_value_div, .timer-btn, .stop-timer {
+  display: none;
 }

--- a/app/controllers/hours_controller.rb
+++ b/app/controllers/hours_controller.rb
@@ -31,7 +31,17 @@ class HoursController < EntriesController
 
   def entry_params
     params.require(:hour).
-      permit(:project_id, :category_id, :value, :description, :date).
-      merge(date: parsed_date(:hour))
+      permit(:project_id, :category_id, :value, :description, :date,
+             :entry_type_option, :timer_value).
+      merge(date: parsed_date(:hour)).
+      to_h.
+      tap do |attributes|
+        if attributes[:entry_type_option] == 'timer' &&
+           attributes.key?(:timer_value)
+          unless attributes[:timer_value].empty?
+            attributes[:value] = attributes[:timer_value]
+          end
+        end
+      end
   end
 end

--- a/app/models/hour.rb
+++ b/app/models/hour.rb
@@ -17,6 +17,8 @@
 class Hour < Entry
   audited allow_mass_assignment: true
 
+  attr_accessor :entry_type_option, :timer_value
+
   belongs_to :category
 
   has_many :taggings, inverse_of: :hour

--- a/app/views/application/_hours_entry_form.html.haml
+++ b/app/views/application/_hours_entry_form.html.haml
@@ -1,5 +1,11 @@
 = simple_form_for @hours_entry do |f|
   = f.error_notification
+  #entry_type_buttons.btn-group
+    = f.input :entry_type_option, as: :hidden, input_html: {value: @hours_entry.entry_type_option || "manual"}
+    %span Manual
+    %span.switch
+      %span.slider.round{"data-value" => "manual"}
+    %span Timer
   = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project")
   = f.association :category, required: true, collection: Category.by_name, label: false, placeholder: t("entries.index.category")
   = f.input :value, required: true, label: false, placeholder: t("entries.index.hours")
@@ -7,4 +13,14 @@
   .taggable
     = f.input :description, input_html: { data: { data: Tag.list }, autocomplete: :off }, label: false, autocomplete: "off", placeholder: t("entries.index.description")
     %span.background-highlighter
+  %div.hour_timer_value_div
+    %span.hours 00
+    %span :
+    %span.minutes 00
+    %span :
+    %span.seconds 00
+  = f.input :timer_value, required: true, label: false, as: :hidden, placeholder: t("entries.index.hours")
   = f.button :submit, data: { disable_with: t("loader.saving") }
+  %div.timer-btn
+    %button.start-timer Start Timer
+    = f.button :submit, "Stop Timer", data: { disable_with: t("loader.saving") }, class: "stop-timer"


### PR DESCRIPTION
**What does this PR do?**
- [x] It adds entry type options (manual and timer) and allows users to start the timer on commencement of task and stop the timer on completion of a task which then creates an hour entry for them.
- [ ] Write Tests for modifications, adding model tests for accessible attributes added and controller params extended

**Description of Task to be completed?**
>- https://github.com/DefactoSoftware/Hours/issues/492

**How should this be manually tested?**
- Running the application tests, making sure none fails including the newly added tests.
- Locate the toggle button on the create hour entry form, click it to toggle to "timer"
- Start the timer and select other required fields
- Stop after a while and notice the creation of the entry

**Any background context you want to provide?**
- If time not up to or more than an hour, the system automatically rounds up the time to one hour
- It also rounds up other time above 1 hour to the nearest hour, so `02:54:12` becomes `03`

**What are the relevant issues?**
- https://github.com/DefactoSoftware/Hours/issues/492

**Screenshots (if appropriate)**
- 
<img width="1129" alt="Screen Shot 2019-04-25 at 9 20 09 PM" src="https://user-images.githubusercontent.com/12856872/56765894-06eaf300-67a0-11e9-8452-c3ba91745ae7.png">
-
<img width="1440" alt="Screen Shot 2019-04-25 at 9 20 20 PM" src="https://user-images.githubusercontent.com/12856872/56765895-06eaf300-67a0-11e9-9bea-d5b416fd8ef5.png">

**Questions:**
- N/A
