### PR TITLE
Capture exception during account creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ruby:2.4.2
 
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
 RUN apt-get update -yqq \
   && apt-get install -yqq --no-install-recommends \
-    postgresql-client \
-    nodejs \
-    qt5-default \
-    libqt5webkit5-dev \
+  postgresql-client \
+  nodejs \
+  qt5-default \
+  libqt5webkit5-dev \
   && apt-get -q clean \
   && rm -rf /var/lib/apt/lists
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -9,8 +9,12 @@ class AccountsController < ApplicationController
   def create
     @signup = Signup.new(signup_params)
     if @signup.valid?
-      Apartment::Tenant.create(@signup.subdomain)
-      Apartment::Tenant.switch(@signup.subdomain)
+      begin 
+        Apartment::Tenant.create(@signup.subdomain)
+        Apartment::Tenant.switch(@signup.subdomain)
+      rescue Apartment::SchemaExists
+        respond_to new_account_url
+      end
       @signup.save
       redirect_to new_user_session_url(subdomain: @signup.subdomain)
     else

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -9,7 +9,7 @@ class AccountsController < ApplicationController
   def create
     @signup = Signup.new(signup_params)
     if @signup.valid?
-      begin 
+      begin
         Apartment::Tenant.create(@signup.subdomain)
         Apartment::Tenant.switch(@signup.subdomain)
       rescue Apartment::SchemaExists


### PR DESCRIPTION
When creating a new account, we get a weird error if the subdomain already exists. I added an exception rescue before the signup form is saved which allows us to change the subdomain and allows the user to know what is going on.