### PR TITLE
Project entries hours validation. 

### DIFF
--- a/app/models/hour.rb
+++ b/app/models/hour.rb
@@ -23,6 +23,7 @@ class Hour < Entry
   has_many :tags, through: :taggings
 
   validates :category, presence: true
+  validates :value, inclusion: { in: 1..24, message: :invalid_hours }
 
   accepts_nested_attributes_for :taggings
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,10 @@ en:
             subdomain:
               invalid_characters: contains invalid characters
               restricted: provided subdomain is restricted
+        hour:
+          attributes:
+            value:
+              invalid_hours: Invalid hours in a day
   back: Back
   billables:
     billable_entries: Billable Entries

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -75,6 +75,10 @@ nl:
             subdomain:
               invalid_characters: bevat ongeldige tekens
               restricted: mits subdomein wordt beperkt
+        hour:
+          attributes:
+            value:
+              invalid_hours: Ongeldige uren op een dag
 
     models:
       user: Gebruiker

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -65,6 +65,10 @@ pl:
             subdomain:
               invalid_characters: zawiera nie poprawne znaki
               restricted: pod warunkiem subdomeny jest ograniczona
+        hour:
+          attributes:
+            value:
+              invalid_hours: Nieprawidłowe godziny w ciągu dnia
   back: Cofnij
   billables:
     billable_entries: Wpisy rozliczone

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -72,6 +72,10 @@ pt-BR:
             subdomain:
               invalid_characters: contêm caracteres inválidos
               restricted: subdomínio informado é restrito
+        hour:
+          attributes:
+            value:
+              invalid_hours: Horas inválidas em um dia
 
     models:
       user: Usuário


### PR DESCRIPTION
## Objective
Restrict hours entry to not more than 24 hours in a day.
Hours should not be more than 24 hours in a day. The system should reject hours greater than 24 in a day.
It should accept hours in the range of 1 to 24.
The error message below popped up when a user entered 34 hours in one day as one entry.
![image](https://user-images.githubusercontent.com/16156641/60131229-8f3a4400-97a1-11e9-9f69-701e2641db41.png)
