### PR TITLE
[feat] Add placeholder improvement to form

### DIFF
--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -4,7 +4,8 @@
     = f.input :name, required: true, placeholder: t("project.form.name")
     = f.input :description, as: :text, input_html: { rows: 5 }, placeholder: t("project.form.description")
     = f.input :budget, as: :integer, placeholder: t("project.form.budget")
-    = f.association :client, required: false, collection: Client.by_name, placeholder: t("project.form.client"), include_blank: t("project.form.no_client")
+    = f.association :client, required: false, collection: Client.by_name, placeholder: t("project.form.client"), 
+      include_blank: t("project.form.no_client")
     = f.label :billable
     = f.input :billable, as: :switch, label: false
     = f.button :submit, data: { disable_with: t("loader.saving") }

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -1,13 +1,15 @@
 = simple_form_for(@project) do |f|
   = f.error_notification
   .form-inputs
-    = f.input :name, required: true
-    = f.input :description, as: :text, input_html: { rows: 5 }
-    = f.input :budget, as: :integer
+    = f.input :name, required: true, placeholder: t("project.form.name")
+    = f.input :description, as: :text, input_html: { rows: 5 }, placeholder: t("project.form.description")
+    = f.input :budget, as: :integer, placeholder: t("project.form.budget")
     = f.association :client, required: false, collection: Client.by_name, placeholder: t("project.form.client"), include_blank: t("project.form.no_client")
     = f.label :billable
     = f.input :billable, as: :switch, label: false
     = f.button :submit, data: { disable_with: t("loader.saving") }
+
+    <p><b>* means that the field is required</b></p>
     
     - if !@project.audits.empty?
       = link_to project_audits_path(@project), class: "audit-link" do

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -2,10 +2,12 @@
   = f.error_notification
   .form-inputs
     = f.input :name, required: true, placeholder: t("project.form.name")
-    = f.input :description, as: :text, input_html: { rows: 5 }, placeholder: t("project.form.description")
+    = f.input :description, as: :text, input_html: { rows: 5 },
+              placeholder: t("project.form.description")
     = f.input :budget, as: :integer, placeholder: t("project.form.budget")
-    = f.association :client, required: false, collection: Client.by_name, placeholder: t("project.form.client"), 
-      include_blank: t("project.form.no_client")
+    = f.association :client, required: false, collection: Client.by_name,
+                    placeholder: t("project.form.client"),
+                    include_blank: t("project.form.no_client")
     = f.label :billable
     = f.input :billable, as: :switch, label: false
     = f.button :submit, data: { disable_with: t("loader.saving") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,9 @@ en:
     form:
       client: Client
       no_client: No Client
+      name: Name of the project
+      description: Brief description of what the project is about
+      budget: Budget in terms of hours
     show:
       changes_link: changes
       edit_link: edit


### PR DESCRIPTION
# Description
Add placeholders that were missing in the project new and edit forms. This will enable the user to understand what the form is about.

## How to test this
- Check out these changes.
- Run the server.
- Navigate to `http://fao.localhost:7000/projects/new` url locally.
- You should be able to see placeholders for each of the inputs of that form.

## Related issue
- None

## Screenshots
<img width="1091" alt="Screen Shot 2019-07-18 at 05 13 34" src="https://user-images.githubusercontent.com/9350722/61424194-64b05680-a91b-11e9-869a-c2e777049073.png">
