### PR TITLE
Validate date for both the hours and mileage entries

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -37,6 +37,10 @@ class EntriesController < ApplicationController
   end
 
   def parsed_date(entry_type)
-    Date.strptime(params[entry_type][:date], DATE_FORMAT)
+    begin
+      Date.strptime(params[entry_type][:date], DATE_FORMAT)
+    rescue ArgumentError
+      nil
+    end
   end
 end

--- a/app/views/application/_hours_entry_form.html.haml
+++ b/app/views/application/_hours_entry_form.html.haml
@@ -3,7 +3,7 @@
   = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project")
   = f.association :category, required: true, collection: Category.by_name, label: false, placeholder: t("entries.index.category")
   = f.input :value, required: true, label: false, placeholder: t("entries.index.hours")
-  = f.input :date, required: true, as: :string, input_html: { value: (@hours_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false
+  = f.input :date, required: true, readonly: true, as: :string, input_html: { value: (@hours_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false
   .taggable
     = f.input :description, input_html: { data: { data: Tag.list }, autocomplete: :off }, label: false, autocomplete: "off", placeholder: t("entries.index.description")
     %span.background-highlighter

--- a/app/views/application/_mileages_entry_form.html.haml
+++ b/app/views/application/_mileages_entry_form.html.haml
@@ -2,5 +2,5 @@
   = f.error_notification
   = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project")
   = f.input :value, required: true, as: :integer, label:false, placeholder: t("entries.index.mileages")
-  = f.input :date, required: true, as: :string, input_html: { value: (@mileages_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false
+  = f.input :date, required: true, readonly: true, as: :string, input_html: { value: (@mileages_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false
   = f.button :submit, data: { disable_with: t("loader.saving") }


### PR DESCRIPTION
**What does this PR do?**

The PR validates the date field for both the hours and mileage entries. 

**Background Context**

Currently, passing in a string value in the date field renders the error below.

<img width="1440" alt="Screenshot 2019-08-25 at 11 44 26" src="https://user-images.githubusercontent.com/25789307/63647691-b96e9a80-c72d-11e9-884a-441a4131fc9a.png">
