### PR TITLE
Remove kgio dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ end
 # caching
 
 gem "dalli" # memcached
-gem "kgio" # faster I/O
 gem "memcachier"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -922,7 +922,6 @@ DEPENDENCIES
   jquery-atwho-rails (~> 1.3.2)
   jquery-rails (~> 4.0)
   kaminari
-  kgio
   launchy
   letter_opener
   memcachier


### PR DESCRIPTION
This is not needed anymore since ruby 2.3

Close https://github.com/DefactoSoftware/Hours/pull/537